### PR TITLE
Fix crash on start-up of MinimalAppSample

### DIFF
--- a/engine/core/modules/platform_app/src/platform/windows/windows_window_manager_impl.cpp
+++ b/engine/core/modules/platform_app/src/platform/windows/windows_window_manager_impl.cpp
@@ -289,8 +289,11 @@ namespace nau
             int height = HIWORD(lParam);
 
             auto* const coreGraphics = getServiceProvider().find<ICoreGraphics>();
-            auto task = coreGraphics->requestViewportResize(width, height, hWnd);
-            task.detach();
+            if (coreGraphics)
+            {
+                auto task = coreGraphics->requestViewportResize(width, height, hWnd);
+                task.detach();
+            }
         }
         else if (message == WM_DESTROY)
         {


### PR DESCRIPTION
This sample application crashes on start-up being built from out-of-box. Reason is an absence of Graphics module, so nullptr check is added. Another approach is to add Graphics module to this sample application, but it pulls scene module, vfx module and so on in this case and this doesn't look like **minimal** application