### PR TITLE
CORE: Fix wrong key for lifeMax in VFXModFXInstance::deserialize

### DIFF
--- a/engine/core/modules/vfx/src/vfx_mod_fx_instance.cpp
+++ b/engine/core/modules/vfx/src/vfx_mod_fx_instance.cpp
@@ -92,7 +92,7 @@ namespace nau::vfx::modfx
 
         // Life
         m_life.part_life_min = blk->getReal("lifeMin", 5.0f);
-        m_life.part_life_max = blk->getReal("lifeMin", 5.0f);
+        m_life.part_life_max = blk->getReal("lifeMax", 5.0f);
         m_life.part_life_rnd_offset = blk->getReal("rndOffset", 0.0f);
         m_life.inst_life_delay = blk->getReal("delay", 0.0f);
         //


### PR DESCRIPTION
The particle `lifeMax `value was incorrectly retrieved using the _lifeMin_ key. Now it uses the correct _lifeMax_ key:
`m_life.part_life_max = blk->getReal("lifeMax", 5.0f);`