### PR TITLE
CORE: fix self-assignment of material fields in Material::clone()

### DIFF
--- a/engine/core/modules/ui/cocos2d-x/cocos/renderer/CCMaterial.cpp
+++ b/engine/core/modules/ui/cocos2d-x/cocos/renderer/CCMaterial.cpp
@@ -524,8 +524,8 @@ Material* Material::clone() const
         // current technique
         auto name = _currentTechnique->getName();
         material->_currentTechnique = material->getTechniqueByName(name);
-        material->_textureSlots = material->_textureSlots;
-        material->_textureSlotIndex = material->_textureSlotIndex;
+        material->_textureSlots = _textureSlots;
+        material->_textureSlotIndex = _textureSlotIndex;
         material->autorelease();
     }
     return material;


### PR DESCRIPTION
Fixes self-assignment of `material->_textureSlots` and `material->_textureSlotIndex` insted of assigning current values when creating new object in `Material::clone()`.