### PR TITLE
CORE: Replace assignments in constructors with initializer lists

### DIFF
--- a/engine/core/kernel/include/nau/math/dag_bounds3.h
+++ b/engine/core/kernel/include/nau/math/dag_bounds3.h
@@ -206,10 +206,10 @@ public:
   Vector3 c;
   float r, r2;
   INLINE BSphere3() { setempty(); }
-  INLINE BSphere3(const Vector3 &p, float s)
+  INLINE BSphere3(const Vector3 &p, float s) :
+    c(p),
+    r(s)
   {
-    c = p;
-    r = s;
     r2 = r * r;
   }
   INLINE BSphere3 &operator=(const BBox3 &a)

--- a/engine/core/kernel/include/nau/math/dag_bounds3.h
+++ b/engine/core/kernel/include/nau/math/dag_bounds3.h
@@ -208,9 +208,9 @@ public:
   INLINE BSphere3() { setempty(); }
   INLINE BSphere3(const Vector3 &p, float s) :
     c(p),
-    r(s)
+    r(s),
+    r2(r * r)
   {
-    r2 = r * r;
   }
   INLINE BSphere3 &operator=(const BBox3 &a)
   {

--- a/engine/core/modules/asset_formats/src/animation/nanim_asset_container.cpp
+++ b/engine/core/modules/asset_formats/src/animation/nanim_asset_container.cpp
@@ -26,9 +26,9 @@ namespace nau
         return nullptr;
     }
 
-    NanimStreamAssetContainer::NanimStreamAssetContainer(io::IStreamReader::Ptr stream)
+    NanimStreamAssetContainer::NanimStreamAssetContainer(io::IStreamReader::Ptr stream) :
+        m_stream(stream)
     {
-        m_stream = stream;
     }
 
     io::IStreamReader::Ptr NanimStreamAssetContainer::getStream()

--- a/engine/core/modules/asset_formats/src/material/material_asset_container.cpp
+++ b/engine/core/modules/asset_formats/src/material/material_asset_container.cpp
@@ -48,10 +48,10 @@ namespace nau
             std::optional<Material> m_material = std::nullopt;
         };
 
-        MaterialAssetContainer::MaterialAssetContainer(io::IStreamReader::Ptr stream)
+        MaterialAssetContainer::MaterialAssetContainer(io::IStreamReader::Ptr stream) :
+            m_stream(stream)
         {
             using namespace nau::io;
-            m_stream = stream;
             size_t prevPosition = stream->getPosition();
             stream->setPosition(io::OffsetOrigin::End, 0);
             m_size = stream->getPosition();

--- a/engine/core/modules/asset_formats/src/shader/shader_asset_container.cpp
+++ b/engine/core/modules/asset_formats/src/shader/shader_asset_container.cpp
@@ -57,11 +57,10 @@ namespace nau
             NAU_CLASS_(nau::ShaderAssetContainer, IAssetContainer)
 
         public:
-            ShaderAssetContainer(io::IStreamReader::Ptr shaderPackStream)
+            ShaderAssetContainer(io::IStreamReader::Ptr shaderPackStream) :
+                m_stream(shaderPackStream)
             {
                 using namespace nau::io;
-
-                m_stream = shaderPackStream;
 
                 auto [packHeader, blobStartOffset] = *io::readContainerHeader(m_stream);
 

--- a/engine/core/modules/graphics/src/render/deferredRT.cpp
+++ b/engine/core/modules/graphics/src/render/deferredRT.cpp
@@ -115,9 +115,9 @@ namespace nau::render
     }
 
     DeferredRT::DeferredRT(const char* name, int w, int h, StereoMode stereoMode, unsigned msaaFlag, int numRT, const unsigned texFmt[MAX_NUM_MRT], uint32_t depthFmt) :
-        m_stereoMode(stereoMode)
+        m_stereoMode(stereoMode),
+        m_name(name)
     {
-        m_name = name;
         uint32_t currentFmt = depthFmt;
         close();
         m_width = w;


### PR DESCRIPTION
Replaced assignments in constructors with initializer lists for various non-trivial members. This avoids the assignment after default construction and reduces unnecessary overhead.