### PR TITLE
CORE: Fix potential memory leak when using realloc

### DIFF
--- a/engine/core/kernel/include/nau/threading/thread_local_value.h
+++ b/engine/core/kernel/include/nau/threading/thread_local_value.h
@@ -233,7 +233,10 @@ namespace nau
                     auto blockSize = (sizeof(Type) + sizeof(Status)) * m_lineSize + alignof(Type) - 1;
 
                     char** temp = static_cast<char**>(realloc(m_memBlock, sizeof(char*) * newSize));
-                    if (!temp) throw std::bad_alloc();
+                    if (!temp)
+                    {
+                        throw std::bad_alloc();
+                    }
                     m_memBlock = temp;
 
                     for(size_t i = m_numLines; i < newSize; i++)

--- a/engine/core/modules/ui/cocos2d-x/cocos/2d/CCDrawNode.cpp
+++ b/engine/core/modules/ui/cocos2d-x/cocos/2d/CCDrawNode.cpp
@@ -101,7 +101,10 @@ void DrawNode::ensureCapacity(int count)
         _bufferCapacity += MAX(_bufferCapacity, count);
 
         V2F_C4B_T2F* temp = static_cast<V2F_C4B_T2F*>(realloc(_buffer, _bufferCapacity * sizeof(V2F_C4B_T2F)));
-        if (!temp) throw std::bad_alloc();
+        if (!temp)
+        {
+            throw std::bad_alloc();
+        }
         _buffer = temp;
         
         _customCommand.createVertexBuffer(sizeof(V2F_C4B_T2F), _bufferCapacity, CustomCommand::BufferUsage::STATIC);

--- a/engine/core/modules/ui/cocos2d-x/cocos/base/ZipUtils.cpp
+++ b/engine/core/modules/ui/cocos2d-x/cocos/base/ZipUtils.cpp
@@ -183,7 +183,10 @@ int ZipUtils::inflateMemoryWithHint(unsigned char *in, ssize_t inLength, unsigne
         if (err != Z_STREAM_END)
         {
             unsigned char* temp = static_cast<unsigned char*>(realloc(*out, bufferSize * BUFFER_INC_FACTOR));
-            if (!temp) throw std::bad_alloc();
+            if (!temp)
+            {
+                throw std::bad_alloc();
+            }
             *out = temp;
             
             /* not enough memory, ouch */

--- a/engine/core/modules/ui/cocos2d-x/cocos/base/ccCArray.cpp
+++ b/engine/core/modules/ui/cocos2d-x/cocos/base/ccCArray.cpp
@@ -98,7 +98,10 @@ void ccArrayShrink(ccArray *arr)
 		}
 		
 		Ref** temp = static_cast<Ref**>(realloc(arr->arr, newSize * sizeof(Ref*)));
-        if (!temp) throw std::bad_alloc();
+        if (!temp)
+        {
+            throw std::bad_alloc();
+        }
         arr->arr = temp;
 
 		CCASSERT(arr->arr!=nullptr,"could not reallocate the memory");

--- a/engine/core/modules/ui/cocos2d-x/cocos/renderer/CCRenderer.cpp
+++ b/engine/core/modules/ui/cocos2d-x/cocos/renderer/CCRenderer.cpp
@@ -628,7 +628,10 @@ void Renderer::drawBatchedTriangles()
             _triBatchesToDrawCapacity *= 1.4;
 
             TriBatchToDraw* temp = static_cast<TriBatchToDraw*>(realloc(_triBatchesToDraw, sizeof(_triBatchesToDraw[0]) * _triBatchesToDrawCapacity));
-            if (!temp) throw std::bad_alloc();
+            if (!temp)
+            {
+                throw std::bad_alloc();
+            }
             _triBatchesToDraw = temp;
         }
 


### PR DESCRIPTION
Checking the result of the `realloc` function for `nullptr`. If memory allocation fails and `realloc` returns `nullptr`, an exception is raised.