### PR TITLE
CORE: Getting rid of memcopy/memset for non-trivial class

### DIFF
--- a/engine/core/modules/dagorECS/include/daECS/core/entityManager.h
+++ b/engine/core/modules/dagorECS/include/daECS/core/entityManager.h
@@ -1398,17 +1398,32 @@ public:
       }
       DelayedEntityCreationChunk(const DelayedEntityCreationChunk&) = delete;
       DelayedEntityCreationChunk& operator=(const DelayedEntityCreationChunk&) = delete;
-      DelayedEntityCreationChunk(DelayedEntityCreationChunk&& a)
-      {
-          memcpy(this, &a, sizeof(DelayedEntityCreationChunk));
-          memset(&a, 0, sizeof(DelayedEntityCreationChunk));
+      DelayedEntityCreationChunk(DelayedEntityCreationChunk&& a) noexcept :
+          queue{std::exchange(a.queue, nullptr)},
+          readFrom{std::exchange(a.readFrom, 0)},
+          writeTo{std::exchange(a.writeTo, 0)},
+          capacity{std::exchange(a.capacity, 0)} 
+      { 
       }
-      DelayedEntityCreationChunk& operator=(DelayedEntityCreationChunk&& a)
+      void swap(DelayedEntityCreationChunk& other) noexcept
       {
-          alignas(DelayedEntityCreationChunk) char buf[sizeof(DelayedEntityCreationChunk)];  // swap
-          memcpy(buf, this, sizeof(DelayedEntityCreationChunk));
-          memcpy(this, &a, sizeof(DelayedEntityCreationChunk));
-          memcpy(&a, buf, sizeof(DelayedEntityCreationChunk));
+          using std::swap;
+          swap(queue, other.queue);
+          swap(readFrom, other.readFrom);
+          swap(writeTo, other.writeTo);
+          swap(capacity, other.capacity);
+
+          /* pvs-studio solution:
+          auto lhs = std::tie(queue, readFrom, writeTo, capacity);
+          auto rhs = std::tie(other.queue, other.readFrom, other.writeTo, other.capacity);
+          std::swap(lhs, rhs);*/
+      }
+      DelayedEntityCreationChunk& operator=(DelayedEntityCreationChunk&& a) noexcept
+      {
+          if (this == std::addressof(a))
+              return *this;
+          auto tmp = std::move(a);
+          swap(tmp);
           return *this;
       }
       DelayedEntityCreation* erase(DelayedEntityCreation* pos)

--- a/engine/core/modules/dagorECS/include/daECS/core/entityManager.h
+++ b/engine/core/modules/dagorECS/include/daECS/core/entityManager.h
@@ -1405,25 +1405,18 @@ public:
           capacity{std::exchange(a.capacity, 0)} 
       { 
       }
-      void swap(DelayedEntityCreationChunk& other) noexcept
-      {
-          using std::swap;
-          swap(queue, other.queue);
-          swap(readFrom, other.readFrom);
-          swap(writeTo, other.writeTo);
-          swap(capacity, other.capacity);
 
-          /* pvs-studio solution:
-          auto lhs = std::tie(queue, readFrom, writeTo, capacity);
-          auto rhs = std::tie(other.queue, other.readFrom, other.writeTo, other.capacity);
-          std::swap(lhs, rhs);*/
-      }
       DelayedEntityCreationChunk& operator=(DelayedEntityCreationChunk&& a) noexcept
       {
           if (this == std::addressof(a))
               return *this;
           auto tmp = std::move(a);
-          swap(tmp);
+          
+          std::swap(queue, tmp.queue);
+          std::swap(readFrom, tmp.readFrom);
+          std::swap(writeTo, tmp.writeTo);
+          std::swap(capacity, tmp.capacity);
+
           return *this;
       }
       DelayedEntityCreation* erase(DelayedEntityCreation* pos)


### PR DESCRIPTION
The behavior of low-level `memcopy`/`memset` operations for non-trivial copyable types may be undefined. `memcopy`/`memset` have been replaced with safe operations.