### PR TITLE
CORE: Casting to size_t before shift operations

### DIFF
--- a/engine/core/modules/ui/cocos2d-x/cocos/renderer/backend/Types.cpp
+++ b/engine/core/modules/ui/cocos2d-x/cocos/renderer/backend/Types.cpp
@@ -37,7 +37,7 @@ bool UniformLocation::operator==(const UniformLocation &other) const
 
 std::size_t UniformLocation::operator()(const UniformLocation &uniform) const
 {
-    return (((size_t)shaderStage) & 0xF) | ((size_t)(location[0]) << 4) | ((size_t)(location[1]) << 8);
+    return (static_cast<size_t>(shaderStage) & 0xF) | (static_cast<size_t>(location[0]) << 4) | (static_cast<size_t>(location[1]) << 8);
 }
 
 CC_BACKEND_END


### PR DESCRIPTION
Shift operations (<<) can cause overflow if the values of `location[0]` or `location[1]` are too large. We should cast `location[0]` and `location[1]` to type `size_t` before performing the shift operation.