### PR TITLE
CORE: Getting rid of const from the return type

### DIFF
--- a/engine/core/kernel/include/nau/version/engine_version.h
+++ b/engine/core/kernel/include/nau/version/engine_version.h
@@ -51,12 +51,12 @@ namespace nau
             return m_patch;
         }
 
-        const nau::string getCommit() const
+        nau::string getCommit() const
         {
             return m_commit;
         }
 
-        const nau::string getBranch() const
+        nau::string getBranch() const
         {
             return m_branch;
         }

--- a/engine/core/modules/dagorECS/include/daECS/core/entityManager.h
+++ b/engine/core/modules/dagorECS/include/daECS/core/entityManager.h
@@ -251,7 +251,7 @@ public:
   // cid is 0.. till getArchetypeNumComponents
   ecs::component_index_t getArchetypeComponentIndex(archetype_t archetype, uint32_t cid) const;
   EntityComponentRef getEntityComponentRef(EntityId eid, uint32_t cid) const;   // cid is 0.. till getNumComponents
-  const ComponentInfo getEntityComponentInfo(EntityId eid, uint32_t cid) const; // cid is 0.. till getNumComponents
+  ComponentInfo getEntityComponentInfo(EntityId eid, uint32_t cid) const; // cid is 0.. till getNumComponents
   bool isEntityComponentSameAsTemplate(ecs::EntityId eid, const EntityComponentRef cref, uint32_t cid) const; // for inspection.
                                                                                                               // returns true, if cid
                                                                                                               // is same as in template
@@ -1852,7 +1852,7 @@ namespace ecs
         return EntityComponentRef(data, dataComponentInfo.componentTypeName, dataComponentInfo.componentType, cIndex);
     }
 
-    inline const EntityManager::ComponentInfo EntityManager::getEntityComponentInfo(EntityId eid, uint32_t cid) const
+    inline EntityManager::ComponentInfo EntityManager::getEntityComponentInfo(EntityId eid, uint32_t cid) const
     {
         EntityComponentRef ref = getEntityComponentRef(eid, cid);
         if(ref.isNull())

--- a/engine/core/modules/ui/cocos2d-x/cocos/base/CCConsole.cpp
+++ b/engine/core/modules/ui/cocos2d-x/cocos/base/CCConsole.cpp
@@ -1575,13 +1575,13 @@ void Console::printFileUtils(int fd)
     FileUtils* fu = FileUtils::getInstance();
     
     Console::Utility::mydprintf(fd, "\nSearch Paths:\n");
-    auto& list = fu->getSearchPaths();
+    auto list = fu->getSearchPaths();
     for( const auto &item : list) {
         Console::Utility::mydprintf(fd, "%s\n", item.c_str());
     }
     
     Console::Utility::mydprintf(fd, "\nResolution Order:\n");
-    auto& list1 = fu->getSearchResolutionsOrder();
+    auto list1 = fu->getSearchResolutionsOrder();
     for( const auto &item : list1) {
         Console::Utility::mydprintf(fd, "%s\n", item.c_str());
     }
@@ -1590,7 +1590,7 @@ void Console::printFileUtils(int fd)
     Console::Utility::mydprintf(fd, "%s\n", fu->getWritablePath().c_str());
     
     Console::Utility::mydprintf(fd, "\nFull Path Cache:\n");
-    auto& cache = fu->getFullPathCache();
+    auto cache = fu->getFullPathCache();
     for( const auto &item : cache) {
         Console::Utility::mydprintf(fd, "%s -> %s\n", item.first.c_str(), item.second.c_str());
     }

--- a/engine/core/modules/ui/cocos2d-x/cocos/platform/CCFileUtils.cpp
+++ b/engine/core/modules/ui/cocos2d-x/cocos/platform/CCFileUtils.cpp
@@ -968,19 +968,19 @@ void FileUtils::addSearchResolutionsOrder(const std::string &order,const bool fr
     }
 }
 
-const std::vector<std::string> FileUtils::getSearchResolutionsOrder() const
+std::vector<std::string> FileUtils::getSearchResolutionsOrder() const
 {
     DECLARE_GUARD;
     return _searchResolutionsOrderArray;
 }
 
-const std::vector<std::string> FileUtils::getSearchPaths() const
+std::vector<std::string> FileUtils::getSearchPaths() const
 {
     DECLARE_GUARD;
     return _searchPathArray;
 }
 
-const std::vector<std::string> FileUtils::getOriginalSearchPaths() const
+std::vector<std::string> FileUtils::getOriginalSearchPaths() const
 {
     DECLARE_GUARD;
     return _originalSearchPaths;
@@ -992,7 +992,7 @@ void FileUtils::setWritablePath(const std::string& writablePath)
     _writablePath = writablePath;
 }
 
-const std::string FileUtils::getDefaultResourceRootPath() const
+std::string FileUtils::getDefaultResourceRootPath() const
 {
     DECLARE_GUARD;
     return _defaultResRootPath;

--- a/engine/core/modules/ui/cocos2d-x/cocos/platform/CCFileUtils.h
+++ b/engine/core/modules/ui/cocos2d-x/cocos/platform/CCFileUtils.h
@@ -407,7 +407,7 @@ public:
      *  @since v2.1
      *  @lua NA
      */
-    virtual const std::vector<std::string> getSearchResolutionsOrder() const;
+    virtual std::vector<std::string> getSearchResolutionsOrder() const;
 
     /**
      *  Sets the array of search paths.
@@ -433,7 +433,7 @@ public:
     /**
      * Get default resource root path.
      */
-    const std::string getDefaultResourceRootPath() const;
+    std::string getDefaultResourceRootPath() const;
 
     /**
      * Set default resource root path.
@@ -457,13 +457,13 @@ public:
      *  @see fullPathForFilename(const char*).
      *  @lua NA
      */
-    virtual const std::vector<std::string> getSearchPaths() const;
+    virtual std::vector<std::string> getSearchPaths() const;
 
     /**
      *  Gets the original search path array set by 'setSearchPaths' or 'addSearchPath'.
      *  @return The array of the original search paths
      */
-    virtual const std::vector<std::string> getOriginalSearchPaths() const;
+    virtual std::vector<std::string> getOriginalSearchPaths() const;
 
     /**
      *  Gets the writable path.
@@ -828,7 +828,7 @@ public:
     virtual void listFilesRecursivelyAsync(const std::string& dirPath, std::function<void(std::vector<std::string>)> callback) const;
 
     /** Returns the full path cache. */
-    const std::unordered_map<std::string, std::string> getFullPathCache() const { return _fullPathCache; }
+    std::unordered_map<std::string, std::string> getFullPathCache() const { return _fullPathCache; }
 
     /**
      *  Gets the new filename from the filename lookup dictionary.

--- a/engine/core/modules/ui/cocos2d-x/cocos/renderer/CCTexture2D.cpp
+++ b/engine/core/modules/ui/cocos2d-x/cocos/renderer/CCTexture2D.cpp
@@ -836,7 +836,7 @@ void Texture2D::initProgram()
     
     //setup vertex layout
     auto vertexLayout = _programState->getVertexLayout();
-    auto& attributes = _programState->getProgram()->getActiveAttributes();
+    auto attributes = _programState->getProgram()->getActiveAttributes();
     auto iter = attributes.find("a_position");
     if(iter != attributes.end())
         vertexLayout->setAttribute("a_position", iter->second.location, backend::VertexFormat::FLOAT2, 0, false);

--- a/engine/core/modules/ui/cocos2d-x/cocos/renderer/backend/Program.h
+++ b/engine/core/modules/ui/cocos2d-x/cocos/renderer/backend/Program.h
@@ -100,7 +100,7 @@ public:
      * Get active vertex attributes.
      * @return Active vertex attributes. key is active attribute name, Value is corresponding attribute info.
      */
-    virtual const std::unordered_map<std::string, AttributeBindInfo> getActiveAttributes() const = 0;
+    virtual std::unordered_map<std::string, AttributeBindInfo> getActiveAttributes() const = 0;
 
     /**
      * Get vertex shader.

--- a/engine/core/modules/ui/src/nau_backend/program_nau.cpp
+++ b/engine/core/modules/ui/src/nau_backend/program_nau.cpp
@@ -96,7 +96,7 @@ eastl::unordered_map<eastl::string, const char*> ShadersToBuildInAttributeNames 
     {"TEXCOORD3", cocos2d::backend::ATTRIBUTE_NAME_TEXCOORD3}
 };
 
-const std::unordered_map<std::string, cocos2d::backend::AttributeBindInfo> ProgramNau::getActiveAttributes() const
+std::unordered_map<std::string, cocos2d::backend::AttributeBindInfo> ProgramNau::getActiveAttributes() const
 {
     std::unordered_map<std::string, cocos2d::backend::AttributeBindInfo> attributesOut;
 

--- a/engine/core/modules/ui/src/nau_backend/program_nau.h
+++ b/engine/core/modules/ui/src/nau_backend/program_nau.h
@@ -97,7 +97,7 @@ public:
      * Get active vertex attributes.
      * @return Active vertex attributes. key is active attribute name, Value is corresponding attribute info.
      */
-    virtual const std::unordered_map<std::string, cocos2d::backend::AttributeBindInfo> getActiveAttributes() const override;
+    virtual std::unordered_map<std::string, cocos2d::backend::AttributeBindInfo> getActiveAttributes() const override;
 
     /**
      * Get uniform buffer size in bytes that can hold all the uniforms.


### PR DESCRIPTION
Returning a constant value from a function can lead to unnecessary copying when the object is initialized with the result of the function call.